### PR TITLE
Implement GitHub authentication provider setup and configuration updates

### DIFF
--- a/backstage/app-config.yaml
+++ b/backstage/app-config.yaml
@@ -1,81 +1,44 @@
 app:
   title: Scaffolded Backstage App
   baseUrl: http://localhost:3000
-
 organization:
   name: My Company
-
 backend:
-  # Used for enabling authentication, secret is shared by all backend plugins
-  # See https://backstage.io/docs/auth/service-to-service-auth for
-  # information on the format
-  # auth:
-  #   keys:
-  #     - secret: ${BACKEND_SECRET}
   baseUrl: http://localhost:7007
   listen:
     port: 7007
-    # Uncomment the following host directive to bind to specific interfaces
-    # host: 127.0.0.1
   csp:
-    connect-src: ["'self'", 'http:', 'https:']
-    # Content-Security-Policy directives follow the Helmet format: https://helmetjs.github.io/#reference
-    # Default Helmet Content-Security-Policy values can be removed by setting the key to false
+    connect-src:
+      - '''self'''
+      - 'http:'
+      - 'https:'
   cors:
     origin: http://localhost:3000
-    methods: [GET, HEAD, PATCH, POST, PUT, DELETE]
+    methods:
+      - GET
+      - HEAD
+      - PATCH
+      - POST
+      - PUT
+      - DELETE
     credentials: true
-  # This is for local development only, it is not recommended to use this in production
-  # The production database configuration is stored in app-config.production.yaml
   database:
-    # If you want to use SQLite instead of Postgres, uncomment the following lines
     client: better-sqlite3
     connection: ':memory:'
-    # config options: https://node-postgres.com/apis/client
-    # If you want to use Postgres, uncomment the following lines
-    # client: pg
-    # connection:
-    #   host: ${POSTGRES_HOST}
-    #   port: ${POSTGRES_PORT}
-    #   user: ${POSTGRES_USER}
-    #   password: ${POSTGRES_PASSWORD}
-  # workingDirectory: /tmp # Use this to configure a working directory for the scaffolder, defaults to the OS temp-dir
-
 integrations:
   github:
     - host: github.com
-      # This is a Personal Access Token or PAT from GitHub. You can find out how to generate this token, and more information
-      # about setting up the GitHub integration here: https://backstage.io/docs/integrations/github/locations#configuration
       token: ${GITHUB_TOKEN}
-    ### Example for how to add your GitHub Enterprise instance using the API:
-    # - host: ghe.example.net
-    #   apiBaseUrl: https://ghe.example.net/api/v3
-    #   token: ${GHE_TOKEN}
-
-proxy:
-  ### Example for how to add a proxy endpoint for the frontend.
-  ### A typical reason to do this is to handle HTTPS and CORS for internal services.
-  # endpoints:
-  #   '/test':
-  #     target: 'https://example.com'
-  #     changeOrigin: true
-
-# Reference documentation http://backstage.io/docs/features/techdocs/configuration
-# Note: After experimenting with basic setup, use CI/CD to generate docs
-# and an external cloud storage when deploying TechDocs for production use-case.
-# https://backstage.io/docs/features/techdocs/how-to-guides#how-to-migrate-from-techdocs-basic-to-recommended-deployment-approach
+proxy: null
 techdocs:
-  builder: 'local' # Alternatives - 'external'
+  builder: local
   generator:
-    runIn: 'docker' # Alternatives - 'local'
+    runIn: docker
   publisher:
-    type: 'local' # Alternatives - 'googleGcs' or 'awsS3'. Read documentation for using alternatives.
-
+    type: local
 auth:
-  # see https://backstage.io/docs/auth/ to learn about auth providers
   environment: development
   providers:
-    # See https://backstage.io/docs/auth/guest/provider
     guest: {}
     github:
       development:
@@ -83,58 +46,38 @@ auth:
         clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
         signIn:
           resolvers:
-            # Matches the GitHub username with the Backstage user entity name.
-            # See https://backstage.io/docs/auth/github/provider#resolvers for more resolvers.
             - resolver: usernameMatchingUserEntityName
-
-scaffolder:
-  # see https://backstage.io/docs/features/software-templates/configuration for software template options
-
+scaffolder: null
 catalog:
   import:
     entityFilename: catalog-info.yaml
     pullRequestBranchName: backstage-integration
   rules:
-    - allow: [Component, System, API, Resource, Location]
+    - allow:
+        - Component
+        - System
+        - API
+        - Resource
+        - Location
   locations:
     - type: file
       target: ../../catalog-info.yaml
-    
-    # Local example data, file locations are relative to the backend process, typically `packages/backend`
     - type: file
       target: ../../examples/entities.yaml
-
-    # Local example template
     - type: file
       target: ../../examples/template/template.yaml
       rules:
-        - allow: [Template]
-
-    # Local example organizational data
+        - allow:
+            - Template
     - type: file
       target: ../../examples/org.yaml
       rules:
-        - allow: [User, Group]
-
-    ## Uncomment these lines to add more example data
-    # - type: url
-    #   target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/all.yaml
-
-    ## Uncomment these lines to add an example org
-    # - type: url
-    #   target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/acme-corp.yaml
-    #   rules:
-    #     - allow: [User, Group]
-
-kubernetes:
-  # see https://backstage.io/docs/features/kubernetes/configuration for kubernetes configuration options
-
-# see https://backstage.io/docs/permissions/getting-started for more on the permission framework
+        - allow:
+            - User
+            - Group
+kubernetes: null
 permission:
-  # setting this to `false` will disable permissions
   enabled: true
-
-# Add this temporarily for debugging
 debug:
   clientId: ${AUTH_GITHUB_CLIENT_ID}
   clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}

--- a/backstage/auth-config.json
+++ b/backstage/auth-config.json
@@ -1,0 +1,5 @@
+{
+    "provider": "github",
+    "clientId": "Ov23liOfPJxKlHMk6Hhn",
+    "clientSecret": "475afd24d67791d9eb18a43852619a4127f7cc19"
+}

--- a/backstage/auth-config.json
+++ b/backstage/auth-config.json
@@ -1,5 +1,5 @@
 {
     "provider": "github",
-    "clientId": "Ov23liOfPJxKlHMk6Hhn",
-    "clientSecret": "475afd24d67791d9eb18a43852619a4127f7cc19"
+    "clientId": "${AUTH_GITHUB_CLIENT_ID}",
+    "clientSecret": "${AUTH_GITHUB_CLIENT_SECRET}"
 }

--- a/backstage/package.json
+++ b/backstage/package.json
@@ -32,9 +32,11 @@
     "@backstage/cli": "^0.34.2",
     "@backstage/e2e-test-utils": "^0.1.1",
     "@playwright/test": "^1.32.3",
+    "@types/node": "^24.6.0",
     "node-gyp": "^10.0.0",
     "prettier": "^2.3.2",
-    "typescript": "~5.8.0"
+    "ts-node": "^10.9.2",
+    "typescript": "^5.9.2"
   },
   "resolutions": {
     "@types/react": "^18",

--- a/backstage/scripts/backend/github.ts
+++ b/backstage/scripts/backend/github.ts
@@ -1,0 +1,27 @@
+// scripts/backend/github.ts
+
+const { readFileSync, writeFileSync } = require("fs");
+const pathModule = require("path");
+
+const backendIndex = pathModule.join(__dirname, "../../packages/backend/src/index.ts");
+
+let content = readFileSync(backendIndex, "utf8");
+
+if (!content.includes("plugin-auth-backend")) {
+    content = `
+import { createBackend } from '@backstage/backend-defaults';
+import auth from '@backstage/plugin-auth-backend';
+import github from '@backstage/plugin-auth-backend-module-github-provider';
+
+${content}
+
+const backend = createBackend();
+backend.add(auth);
+backend.add(github);
+backend.start();
+  `;
+    writeFileSync(backendIndex, content, "utf8");
+    console.log("✅ Backend index.ts updated for GitHub provider");
+} else {
+    console.log("ℹ️ Backend already configured for GitHub provider");
+}

--- a/backstage/scripts/frontend/github.ts
+++ b/backstage/scripts/frontend/github.ts
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+
+// --- Update app-config.yaml ---
+const configPath = path.join(__dirname, '../../app-config.yaml');
+const config = yaml.load(fs.readFileSync(configPath, 'utf8'));
+
+
+// Ensure auth.providers.github.development exists
+config.auth = config.auth || {};
+config.auth.environment = 'development';
+config.auth.providers = config.auth.providers || {};
+config.auth.providers.github = {
+    development: {
+        clientId: '${AUTH_GITHUB_CLIENT_ID}',
+        clientSecret: '${AUTH_GITHUB_CLIENT_SECRET}',
+        signIn: {
+            resolvers: [
+                { resolver: 'usernameMatchingUserEntityName' },
+            ],
+        },
+    },
+};
+
+
+fs.writeFileSync(configPath, yaml.dump(config), 'utf8');
+console.log('✅ app-config.yaml updated for GitHub provider');
+
+
+// --- Update App.tsx ---
+const appFilePath = path.join(__dirname, '../../packages/app/src/App.tsx');
+let appCode = fs.readFileSync(appFilePath, 'utf8');
+
+
+// Add imports if missing
+if (!appCode.includes("githubAuthApiRef")) {
+    appCode =
+        "import { githubAuthApiRef } from '@backstage/core-plugin-api';\n" +
+        "import { SignInPage } from '@backstage/core-components';\n" +
+        appCode;
+}
+
+
+// Add SignInPage config if missing
+if (!appCode.includes("github-auth-provider")) {
+    const createAppRegex = /const app = createApp\(\{\s*components:\s*\{/;
+    appCode = appCode.replace(createAppRegex, `const app = createApp({\n  components: {\n    SignInPage: props => (\n      <SignInPage\n        {...props}\n        auto\n        provider={{\n          id: 'github-auth-provider',\n          title: 'GitHub',\n          message: 'Sign in using GitHub',\n          apiRef: githubAuthApiRef,\n        }}\n      />\n    ),`);
+}
+
+
+fs.writeFileSync(appFilePath, appCode, 'utf8');
+console.log('✅ App.tsx updated for GitHub provider');

--- a/backstage/scripts/setup-auth.js
+++ b/backstage/scripts/setup-auth.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+'use strict';
+
+var execSync = require('child_process').execSync;
+var path = require('path');
+var fs = require('fs');
+
+var configPath = path.join(__dirname, '../auth-config.json');
+
+if (!fs.existsSync(configPath)) {
+  console.error('❌ Missing auth-config.json. Please create it first.');
+  process.exit(1);
+}
+
+var config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+var provider = config.provider;
+
+if (!provider) {
+  console.error('❌ No provider defined in auth-config.json');
+  process.exit(1);
+}
+
+// Build paths to provider scripts
+var frontendScript = path.join(__dirname, 'frontend/' + provider + '.ts');
+var backendScript = path.join(__dirname, 'backend/' + provider + '.ts');
+
+try {
+  console.log('⚙️  Setting up auth provider: ' + provider + '...');
+
+  if (fs.existsSync(frontendScript)) {
+    execSync('yarn ts-node ' + frontendScript, { stdio: 'inherit' });
+  } else {
+    console.warn('⚠️ No frontend script found for ' + provider);
+  }
+
+  if (fs.existsSync(backendScript)) {
+    execSync('yarn ts-node ' + backendScript, { stdio: 'inherit' });
+  } else {
+    console.warn('⚠️ No backend script found for ' + provider);
+  }
+
+  console.log('✅ Auth setup completed for ' + provider);
+} catch (err) {
+  console.error('❌ Failed to run auth setup:', err.message);
+  process.exit(1);
+}

--- a/backstage/tsconfig.json
+++ b/backstage/tsconfig.json
@@ -6,12 +6,18 @@
     "plugins/*/src",
     "plugins/*/config.d.ts",
     "plugins/*/dev",
-    "plugins/*/migrations"
+    "plugins/*/migrations",
+    "scripts/**/*"
   ],
-  "exclude": ["node_modules"],
+  "exclude": [
+    "node_modules"
+  ],
   "compilerOptions": {
     "outDir": "dist-types",
     "rootDir": ".",
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
   }
 }

--- a/backstage/yarn.lock
+++ b/backstage/yarn.lock
@@ -13146,6 +13146,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:^24.6.0":
+  version: 24.6.0
+  resolution: "@types/node@npm:24.6.0"
+  dependencies:
+    undici-types: "npm:~7.13.0"
+  checksum: 10c0/06f1aa1b5d9a8c26285b34c25aee554f31a1dc0b39627cc14e7c1c6967e75a47ab9f409eee14796cbcc004ae4059fa884cb6092ecfb368c9656d16686d7cc9d8
+  languageName: node
+  linkType: hard
+
 "@types/parse-json@npm:^4.0.0":
   version: 4.0.2
   resolution: "@types/parse-json@npm:4.0.2"
@@ -28785,10 +28794,12 @@ __metadata:
     "@backstage/e2e-test-utils": "npm:^0.1.1"
     "@backstage/plugin-auth-backend-module-github-provider": "npm:^0.3.7"
     "@playwright/test": "npm:^1.32.3"
+    "@types/node": "npm:^24.6.0"
     dotenv: "npm:^17.2.3"
     node-gyp: "npm:^10.0.0"
     prettier: "npm:^2.3.2"
-    typescript: "npm:~5.8.0"
+    ts-node: "npm:^10.9.2"
+    typescript: "npm:^5.9.2"
   languageName: unknown
   linkType: soft
 
@@ -30865,7 +30876,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-node@npm:^10.9.1":
+"ts-node@npm:^10.9.1, ts-node@npm:^10.9.2":
   version: 10.9.2
   resolution: "ts-node@npm:10.9.2"
   dependencies:
@@ -31143,6 +31154,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:^5.9.2":
+  version: 5.9.2
+  resolution: "typescript@npm:5.9.2"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/cd635d50f02d6cf98ed42de2f76289701c1ec587a363369255f01ed15aaf22be0813226bff3c53e99d971f9b540e0b3cc7583dbe05faded49b1b0bed2f638a18
+  languageName: node
+  linkType: hard
+
 "typescript@npm:~5.5.0":
   version: 5.5.4
   resolution: "typescript@npm:5.5.4"
@@ -31153,13 +31174,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~5.8.0":
-  version: 5.8.3
-  resolution: "typescript@npm:5.8.3"
+"typescript@patch:typescript@npm%3A^5.9.2#optional!builtin<compat/typescript>":
+  version: 5.9.2
+  resolution: "typescript@patch:typescript@npm%3A5.9.2#optional!builtin<compat/typescript>::version=5.9.2&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/5f8bb01196e542e64d44db3d16ee0e4063ce4f3e3966df6005f2588e86d91c03e1fb131c2581baf0fb65ee79669eea6e161cd448178986587e9f6844446dbb48
+  checksum: 10c0/34d2a8e23eb8e0d1875072064d5e1d9c102e0bdce56a10a25c0b917b8aa9001a9cf5c225df12497e99da107dc379360bc138163c66b55b95f5b105b50578067e
   languageName: node
   linkType: hard
 
@@ -31170,16 +31191,6 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/73409d7b9196a5a1217b3aaad929bf76294d3ce7d6e9766dd880ece296ee91cf7d7db6b16c6c6c630ee5096eccde726c0ef17c7dfa52b01a243e57ae1f09ef07
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@npm%3A~5.8.0#optional!builtin<compat/typescript>":
-  version: 5.8.3
-  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/39117e346ff8ebd87ae1510b3a77d5d92dae5a89bde588c747d25da5c146603a99c8ee588c7ef80faaf123d89ed46f6dbd918d534d641083177d5fac38b8a1cb
   languageName: node
   linkType: hard
 
@@ -31266,6 +31277,13 @@ __metadata:
   version: 7.12.0
   resolution: "undici-types@npm:7.12.0"
   checksum: 10c0/326e455bbc0026db1d6b81c76a1cf10c63f7e2f9821db2e24fdc258f482814e5bfa8481f8910d07c68e305937c5c049610fdc441c5e8b7bb0daca7154fb8a306
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~7.13.0":
+  version: 7.13.0
+  resolution: "undici-types@npm:7.13.0"
+  checksum: 10c0/44bbb0935425291351bfd8039571f017295b5d6dc5727045d0a4fea8c6ffe73a6703b48ce010f9cb539b9041a75b463f8cfe1e7309cab7486452505fb0d66151
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request introduces a streamlined setup for GitHub authentication in the Backstage app, automating both frontend and backend configuration through new scripts and configuration files. It also updates TypeScript dependencies and configuration to support these scripts. The main changes are grouped below:

**Authentication Provider Automation**

* Added `auth-config.json` for specifying the authentication provider and its credentials, enabling easy switching or setup of providers.
* Introduced `scripts/setup-auth.js`, which reads `auth-config.json` and runs provider-specific frontend and backend setup scripts for authentication.
* Added provider-specific scripts: `scripts/frontend/github.ts` updates `app-config.yaml` and `App.tsx` for GitHub auth, while `scripts/backend/github.ts` configures the backend for GitHub authentication. [[1]](diffhunk://#diff-1a4858b5496d68469ad15aee70488629043677df323c5809fc2119d786aa03a4R1-R57) [[2]](diffhunk://#diff-d5bbc2cfc01d9652aa5f6cc100e4ff6077f259502ea1e4c8c5305a6ef9412716R1-R27)

**Configuration and Dependency Updates**

* Refactored `app-config.yaml` to use YAML objects instead of arrays for improved readability and script compatibility, and set unused sections (like `proxy`, `scaffolder`, `kubernetes`) to `null` for clarity.
* Updated `package.json` to add `@types/node`, `ts-node`, and bump `typescript` to `^5.9.2`, supporting the new TypeScript scripts.
* Modified `tsconfig.json` to include the `scripts` directory, improve module resolution, and add compatibility options for TypeScript scripts.